### PR TITLE
feat: change of coordinate system to +X Front +Y Right +Z Depth

### DIFF
--- a/models/dave_robot_models/description/glider_nautilus/model.sdf
+++ b/models/dave_robot_models/description/glider_nautilus/model.sdf
@@ -32,7 +32,7 @@
           <izz>10.32</izz>
         </inertia> -->
 
-        <pose>0 0.528 -0.00768 0 0 0</pose>
+        <pose>0.074 0 -0.00768 0 0 0</pose>
         <mass>51.845</mass><!--from 58.245 (minus 6.4 ACU) to 51.845-->
         <inertia>
           <ixx>10.24</ixx>
@@ -46,7 +46,7 @@
       </inertial>
 
       <visual name="base_link_visual">
-        <pose>0 0 0 0 0 0</pose>
+        <pose>0 0 0 0 0 1.5708</pose>
         <geometry>
           <mesh>
             <!-- Model without wings and rudder. Frame corresponds to frame in 
@@ -80,12 +80,12 @@
       <collision name="base_link_collision">
         <!-- This determines the buoyancy.
              Hull starts at base frame, centre 0.5m from base frame -->
-        <pose>0 0.5 0 0 0 0</pose>
+        <pose>0.027 0 0 0 0 0</pose>
         <geometry>
           <box>
             <!-- Volume 0.053m^3 + 0.010098m^3 ie. volume of the hull
             plus the volume needed to compensate for neutrall buoyant parts-->
-            <size>0.230217 1.190528 0.230217</size>  
+            <size>1.190528 0.230217 0.230217</size>  
           </box>
         </geometry>
       </collision>
@@ -112,8 +112,8 @@
 
       <!-- Linear Drag Coefficients -->
       <!-- diagonal terms -->
-      <xU>-108</xU>
-      <yV>-8</yV>
+      <xU>-8</xU>
+      <yV>-108</yV>
       <zW>-162</zW>
       <kP>-32</kP>
       <mQ>-13</mQ>
@@ -140,6 +140,7 @@
            For now simply rest at base link -->
       
       <visual name="LeftFin_visual">
+        <pose>0 0 0 0 0 1.5708</pose>
         <geometry>
           <mesh>
             <uri>model://meshes/glider_nautilus/nautilus_glider_wing_l_v03.dae</uri>
@@ -156,7 +157,7 @@
            centre of pressure passed to the lift drag plugin. Insert 
            the same position in the pose tag. -->
       <visual name="centre_of_pressure_marker">
-        <pose>0.408 1.205 0 0 0 0</pose>
+        <pose>1.205 -0.408 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.01</radius>
@@ -188,12 +189,12 @@
       <alpha_stall>0.17</alpha_stall>
       <a0>0</a0>
       <area>0.0725</area>
-      <upward>0 0 1</upward>
-      <forward>0 -1 0</forward>
+      <upward>0 0 -1</upward>
+      <forward>1 0 0</forward>
       <link_name>LeftFin_link</link_name>
       <!-- cp determines the centre of pressure in the link frame,
            i.e. wher the aerodynamic forces are applied -->
-      <cp>0.408 1.205 0</cp>
+      <cp>-1.205 -0.408  0</cp>
     </plugin>
 
     <!-- RIGHT FIN -->
@@ -201,6 +202,7 @@
     <link name="RightFin_link">
       
       <visual name="RightFin_visual">
+        <pose>0 0 0 0 0 1.5708</pose>
         <geometry>
           <mesh>
             <uri>model://meshes/glider_nautilus/nautilus_glider_wing_r_v03.dae</uri>
@@ -217,7 +219,7 @@
            centre of pressure passed to the lift drag plugin. Insert 
            the same position in the pose tag. -->
       <visual name="centre_of_pressure_marker">
-        <pose>-0.408 1.205 0 0 0 0</pose>
+        <pose>1.205 0.408  0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.01</radius>
@@ -249,12 +251,12 @@
       <alpha_stall>0.17</alpha_stall>
       <a0>0</a0>
       <area>0.0725</area>
-      <upward>0 0 1</upward>
-      <forward>0 -1 0</forward>
+      <upward>0 0 -1</upward>
+      <forward>1 0 0</forward>
       <link_name>RightFin_link</link_name>
       <!-- cp determines the centre of pressure in the link frame,
            i.e. wher the aerodynamic forces are applied -->
-      <cp>-0.408 1.205 0</cp>
+      <cp>-1.205 0.408 0</cp>
     </plugin>
 
     <!-- TOP RUDDER -->
@@ -264,6 +266,7 @@
       <pose relative_to="TopRudder_joint">0 0 0 0 0 0</pose>
       
       <visual name="Rudder_visual">
+        <pose>0.1 0 0.2 0 0 1.5708</pose>
         <geometry>
           <mesh>
             <uri>model://meshes/glider_nautilus/nautilus_glider_rudder_v04.dae</uri>
@@ -280,7 +283,7 @@
            centre of pressure passed to the lift drag plugin. Insert 
            the same position in the pose tag. -->
       <visual name="centre_of_pressure_marker">
-        <pose relative_to="TopRudder_link">0 0.04 0.1 0 0 0</pose>
+        <pose relative_to="TopRudder_link">0 0.04 -0.1 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.01</radius>
@@ -296,7 +299,7 @@
     </link>
 
     <joint name="TopRudder_joint" type="fixed">
-      <pose relative_to="base_link">0 1.404 0.119 0 0 0</pose>
+      <pose relative_to="base_link">-1.404 0 -0.119 0 0 0</pose>
       <parent>base_link</parent>
       <child>TopRudder_link</child>
     </joint>
@@ -350,14 +353,14 @@
       <upward>0 1 0</upward>
       <forward>1 0 0</forward>
       <link_name>TopRudder_link</link_name>
-      <cp>0 0.04 0.1</cp>
+      <cp>-0.04 0 -0.1</cp>
     </plugin>
 
     <!-- BLADDER -->
 
     <link name="bladder_link">
       <!-- Pose of bladder link in base link frame-->
-      <pose>0 -0.105 0 0 0 0</pose>
+      <pose>0.5 0 0 0 0 0</pose>
       <visual name="bladder_link_visual">
         <geometry>
           <sphere>
@@ -385,7 +388,7 @@
     <link name="oil_weight_link">
       <!--Oil positioned in the middle between the 
       tank and the bladder. Static. Position in base_link coord-->
-      <pose>0 0.0855 -0.0185 0 0 0</pose>
+      <pose>0.2 0 -0.0185 0 0 0</pose>
       <visual name="oil_weight_marker">
         <pose>0 0 0 0 0 0</pose>
         <geometry>
@@ -501,11 +504,11 @@
     </link>
 
     <joint name='acu_tilt_joint' type='prismatic'>
-      <pose>0 -0.318 0.044 0 0 0</pose> <!--CHECK AXIS DEFINITION-->
+      <pose>-0.393 0 0.044 0 0 0</pose> <!--CHECK AXIS DEFINITION-->
       <parent>base_link</parent>
       <child>acu_tilt_link</child>
       <axis>
-        <xyz>0 1 0</xyz>
+        <xyz>1 0 0</xyz>
         <limit>
           <lower>-0.393</lower> <!-- Minimum position (in meters) -->
           <upper>-0.243</upper>  <!-- Maximum position (in meters) -->
@@ -534,11 +537,11 @@
     </link>
 
     <joint name='acu_roll_joint' type='revolute'>
-      <pose>0 -0.4 -0.07 0 0 0</pose> <!--CHECK AXIS DEFINITION-->
+      <pose>-0.4 0 -0.07 0 0 0</pose> <!--CHECK AXIS DEFINITION-->
       <parent>base_link</parent>
       <child>acu_roll_link</child>
       <axis>
-        <xyz>0 1 0</xyz>
+        <xyz>1 0 0</xyz>
         <limit>
           <lower>-0.5236</lower> <!-- Minimum position (in degrees) -->
           <upper>0.5236</upper>  <!-- Maximum position (in degrees) -->


### PR DESCRIPTION
I updated the coordinate systems to the standard: +X Front +Y Right +Z Depth. The one from the spreadsheet.

# Changes that had to be made:
- all things (moments of inertia, poses, sizes) had to be translated from -Y front to +X front. This was finicky to get right because there are many things and all must be correct.
- visuals had to be rotated since the mesh uses the Onshape coordinates
- the Origin of the coordinate system is the center of the vehicle (pretty sure but not fully). We were nosediving because CM was placed very in front of the vehicle. Others (Center of pressure, bladder position) had to be adapted to prevent nosediving.

# Future (!):
- it seems that the values from the spreadsheet are roughly correct and do make the simulation better. We need to rigorously go over them and try to make the simulation match them. 